### PR TITLE
TK-36: Enhance network layer

### DIFF
--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/LoginPageActivity.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/LoginPageActivity.java
@@ -13,6 +13,7 @@ import com.hunk.nobank.NoBankApplication;
 import com.hunk.nobank.R;
 import com.hunk.nobank.manager.LoginManager;
 import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.ViewManagerListener;
 import com.hunk.nobank.model.login.LoginReqPackage;
 import com.hunk.nobank.util.StringUtils;
 
@@ -110,9 +111,9 @@ public class LoginPageActivity extends AccountBaseActivity {
         }
     }
 
-    private ManagerListener mManagerListener = new ManagerListener() {
+    private ViewManagerListener mManagerListener = new ViewManagerListener(this) {
         @Override
-        public void success(String managerId, String messageId, Object data) {
+        public void onSuccess(String managerId, String messageId, Object data) {
             if (managerId.equals(mLoginManager.getManagerId())) {
                 if (messageId.equals(LoginManager.METHOD_LOGIN)) {
                     dismissLoading();
@@ -129,7 +130,7 @@ public class LoginPageActivity extends AccountBaseActivity {
         }
 
         @Override
-        public void failed(String managerId, String messageId, Object data) {
+        public void onFailed(String managerId, String messageId, Object data) {
             if (managerId.equals(mLoginManager.getManagerId())) {
                 if (messageId.equals(LoginManager.METHOD_LOGIN)) {
                     dismissLoading();

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/ViewManagerListener.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/ViewManagerListener.java
@@ -1,0 +1,35 @@
+package com.hunk.nobank.manager;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Since Android will recycle the activity or fragment sometimes, but our listener is holding in manager layer.
+ * Which means when activity has been recycled and Callback return at same time,
+ * if call any method like 'dismissDialog' in callback method, it will provoke NullPointerException.
+ */
+public abstract class ViewManagerListener implements ManagerListener {
+
+    private final WeakReference<Object> weakRefer;
+
+    public ViewManagerListener(Object o) {
+        this.weakRefer = new WeakReference<>(o);
+    }
+
+    @Override
+    public void success(String managerId, String messageId, Object data) {
+        if (weakRefer.get() != null) {
+            onSuccess(managerId, messageId, data);
+        }
+    }
+
+    @Override
+    public void failed(String managerId, String messageId, Object data) {
+        if (weakRefer.get() != null) {
+            onFailed(managerId, messageId, data);
+        }
+    }
+
+    public abstract void onSuccess(String managerId, String messageId, Object data);
+
+    public abstract void onFailed(String managerId, String messageId, Object data);
+}


### PR DESCRIPTION
1. When activity has been recycled, we need check if activity still alive when callback return. Avoid NullPointerException occurs.