### PR TITLE
Check cache in main thread by returning boolean in fetching method

### DIFF
--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/Core.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/Core.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import com.hunk.nobank.extension.network.MyNetworkHandler;
 import com.hunk.nobank.extension.network.NetworkHandler;
 import com.hunk.nobank.manager.UserManager;
-import com.hunk.nobank.manager.flow.ScreenFlowManager;
+import com.hunk.nobank.manager.ScreenFlowManager;
 import com.hunk.nobank.model.Cache;
 import com.hunk.nobank.util.Logging;
 import com.hunk.nobank.util.ViewHelper;

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/BalanceFragment.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/BalanceFragment.java
@@ -13,9 +13,9 @@ import com.hunk.nobank.Core;
 import com.hunk.nobank.R;
 import com.hunk.nobank.contract.AccountType;
 import com.hunk.nobank.manager.AccountDataManager;
-import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.manager.UserManager;
-import com.hunk.nobank.manager.ViewManagerListener;
+import com.hunk.nobank.manager.dataBasic.ViewManagerListener;
 import com.hunk.nobank.model.AccountSummaryPackage;
 
 public class BalanceFragment extends Fragment {
@@ -58,8 +58,6 @@ public class BalanceFragment extends Fragment {
     private void setupUI(View view) {
         mBalance = (TextView) view.findViewById(R.id.txt_balance);
         mUserLogo = (ImageView) view.findViewById(R.id.user_logo);
-
-        mBalance.setText(R.string.loading_balance);
     }
 
     @Override
@@ -72,6 +70,8 @@ public class BalanceFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        mUserManager.fetchAccountSummary(new AccountSummaryPackage(), mViewManagerListener);
+        if (mUserManager.fetchAccountSummary(new AccountSummaryPackage(), mViewManagerListener)) {
+            mBalance.setText(R.string.loading_balance);
+        }
     }
 }

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/LoginPageActivity.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/LoginPageActivity.java
@@ -11,7 +11,7 @@ import com.hunk.nobank.Core;
 import com.hunk.nobank.NoBankApplication;
 import com.hunk.nobank.R;
 import com.hunk.nobank.manager.UserManager;
-import com.hunk.nobank.manager.ViewManagerListener;
+import com.hunk.nobank.manager.dataBasic.ViewManagerListener;
 import com.hunk.nobank.model.AccountSummaryPackage;
 import com.hunk.nobank.model.LoginReqPackage;
 import com.hunk.nobank.util.StringUtils;

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/payment/PaymentMainActivity.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/payment/PaymentMainActivity.java
@@ -7,7 +7,7 @@ import com.hunk.nobank.Core;
 import com.hunk.nobank.R;
 import com.hunk.nobank.activity.BaseActivity;
 import com.hunk.nobank.flow.P2pScreenFlow;
-import com.hunk.nobank.manager.flow.ScreenFlow;
+import com.hunk.nobank.manager.flowBasic.ScreenFlow;
 
 public class PaymentMainActivity extends BaseActivity {
 

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/transaction/TransactionListFragment.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/activity/transaction/TransactionListFragment.java
@@ -13,10 +13,10 @@ import com.hunk.nobank.Core;
 import com.hunk.nobank.R;
 import com.hunk.nobank.contract.TransactionFields;
 import com.hunk.nobank.extension.view.NBProgressView;
-import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.manager.TransactionDataManager;
 import com.hunk.nobank.manager.UserManager;
-import com.hunk.nobank.manager.ViewManagerListener;
+import com.hunk.nobank.manager.dataBasic.ViewManagerListener;
 import com.hunk.nobank.model.TransactionReqPackage;
 import com.hunk.nobank.views.PullToRefreshListView;
 

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/extension/network/MyNetworkHandler.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/extension/network/MyNetworkHandler.java
@@ -5,7 +5,7 @@ import android.os.Handler;
 import android.os.Message;
 
 import com.hunk.nobank.contract.RealResp;
-import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.model.Cacheable;
 import com.hunk.nobank.util.Logging;
 import com.squareup.okhttp.Callback;
@@ -103,7 +103,7 @@ public class MyNetworkHandler extends NetworkHandler {
         return realResp;
     }
 
-    static class Wrapper {
+    public static class Wrapper {
         public final String managerId;
         public final ManagerListener listener;
         public final Object realResp;

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/extension/network/NetworkHandler.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/extension/network/NetworkHandler.java
@@ -25,6 +25,10 @@ public class NetworkHandler {
     private RequestQueue mQueue;
 
     public NetworkHandler(Context ctx) {
+        setupVolley(ctx);
+    }
+
+    protected void setupVolley(Context ctx) {
         mQueue = Volley.newRequestQueue(ctx, null, 1024*1024);
     }
 

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/extension/network/NetworkHandler.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/extension/network/NetworkHandler.java
@@ -14,7 +14,7 @@ import com.google.gson.Gson;
 import com.hunk.nobank.contract.ContractGson;
 import com.hunk.nobank.contract.RealReq;
 import com.hunk.nobank.contract.RealResp;
-import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.util.Logging;
 
 import java.io.UnsupportedEncodingException;

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/flow/P2pScreenFlow.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/flow/P2pScreenFlow.java
@@ -2,8 +2,8 @@ package com.hunk.nobank.flow;
 
 import android.app.Activity;
 
-import com.hunk.nobank.manager.flow.ScreenFlow;
-import com.hunk.nobank.manager.flow.ScreenFlowManager;
+import com.hunk.nobank.manager.flowBasic.ScreenFlow;
+import com.hunk.nobank.manager.ScreenFlowManager;
 
 /**
  * @author HunkDeng

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/AccountDataManager.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/AccountDataManager.java
@@ -1,6 +1,7 @@
 package com.hunk.nobank.manager;
 
 import com.hunk.nobank.contract.AccountModel;
+import com.hunk.nobank.manager.dataBasic.DataManager;
 
 /**
  *

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/ScreenFlowManager.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/ScreenFlowManager.java
@@ -1,4 +1,6 @@
-package com.hunk.nobank.manager.flow;
+package com.hunk.nobank.manager;
+
+import com.hunk.nobank.manager.flowBasic.ScreenFlow;
 
 /**
  * @author HunkDeng

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/TransactionDataManager.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/TransactionDataManager.java
@@ -5,6 +5,8 @@ import com.hunk.nobank.contract.AccountSummary;
 import com.hunk.nobank.contract.RealResp;
 import com.hunk.nobank.contract.TransactionFields;
 import com.hunk.nobank.extension.network.BaseReqPackage;
+import com.hunk.nobank.manager.dataBasic.DataManager;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.model.Cache;
 import com.hunk.nobank.model.TransactionReqPackage;
 
@@ -28,7 +30,15 @@ public class TransactionDataManager extends DataManager {
     }
 
     public static final String METHOD_TRANSACTION = "METHOD_TRANSACTION";
-    public void fetchTransactions(boolean more, ManagerListener managerListener) {
+
+    /**
+     *
+     * @param more
+     * @param managerListener
+     * @return
+     *  Whether app call network request
+     */
+    public boolean fetchTransactions(boolean more, ManagerListener managerListener) {
         TransactionListCache cache = (TransactionListCache) TransactionReqPackage.cache;
         cache.setMore(more);
 
@@ -40,8 +50,10 @@ public class TransactionDataManager extends DataManager {
             Core.getInstance().getNetworkHandler()
                     .fireRequest(managerListener, transactionReqPackage,
                             getManagerId(), METHOD_TRANSACTION);
+            return true;
         } else {
             managerListener.success(getManagerId(), METHOD_TRANSACTION, TransactionReqPackage.cache.get());
+            return false;
         }
     }
 

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/UserManager.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/UserManager.java
@@ -9,6 +9,8 @@ import com.hunk.nobank.contract.AccountSummary;
 import com.hunk.nobank.contract.AccountType;
 import com.hunk.nobank.contract.LoginResp;
 import com.hunk.nobank.contract.RealResp;
+import com.hunk.nobank.manager.dataBasic.DataManager;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.model.AccountSummaryPackage;
 import com.hunk.nobank.model.LoginReqPackage;
 
@@ -107,7 +109,14 @@ public class UserManager extends DataManager {
     }
 
     public static final String METHOD_ACCOUNT_SUMMARY = "METHOD_ACCOUNT_SUMMARY";
-    public void fetchAccountSummary(
+
+    /**
+     * @param req
+     * @param listener
+     * @return
+     *  Whether application call network request
+     */
+    public boolean fetchAccountSummary(
             AccountSummaryPackage req, final ManagerListener listener) {
         if (AccountSummaryPackage.cache.shouldFetch(req)) {
             Core.getInstance().getNetworkHandler()
@@ -126,8 +135,10 @@ public class UserManager extends DataManager {
                             listener.failed(managerId, messageId, data);
                         }
                     }, req, getManagerId(), METHOD_ACCOUNT_SUMMARY);
+            return true;
         } else {
             listener.success(getManagerId(), METHOD_ACCOUNT_SUMMARY, AccountSummaryPackage.cache.get());
+            return false;
         }
     }
 

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/dataBasic/DataManager.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/dataBasic/DataManager.java
@@ -1,4 +1,4 @@
-package com.hunk.nobank.manager;
+package com.hunk.nobank.manager.dataBasic;
 
 public abstract class DataManager {
     public abstract String getManagerId();

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/dataBasic/ManagerListener.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/dataBasic/ManagerListener.java
@@ -1,4 +1,4 @@
-package com.hunk.nobank.manager;
+package com.hunk.nobank.manager.dataBasic;
 
 public interface ManagerListener {
     void success(String managerId, String messageId, Object data);

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/dataBasic/ViewManagerListener.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/dataBasic/ViewManagerListener.java
@@ -1,4 +1,4 @@
-package com.hunk.nobank.manager;
+package com.hunk.nobank.manager.dataBasic;
 
 import java.lang.ref.WeakReference;
 

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/flowBasic/ScreenFlow.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/flowBasic/ScreenFlow.java
@@ -1,7 +1,9 @@
-package com.hunk.nobank.manager.flow;
+package com.hunk.nobank.manager.flowBasic;
 
 import android.app.Activity;
 import android.content.Intent;
+
+import com.hunk.nobank.manager.ScreenFlowManager;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/flowBasic/ScreenNode.java
+++ b/NobankCore/noBank/src/main/java/com/hunk/nobank/manager/flowBasic/ScreenNode.java
@@ -1,4 +1,4 @@
-package com.hunk.nobank.manager.flow;
+package com.hunk.nobank.manager.flowBasic;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;

--- a/NobankCore/noBank/src/test/java/com/hunk/test/nobank/dataMgrTest/TransactionDataManagerTest.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/nobank/dataMgrTest/TransactionDataManagerTest.java
@@ -2,10 +2,11 @@ package com.hunk.test.nobank.dataMgrTest;
 
 import com.hunk.nobank.BuildConfig;
 import com.hunk.nobank.Core;
+import com.hunk.nobank.contract.AccountSummary;
 import com.hunk.nobank.contract.RealResp;
 import com.hunk.nobank.contract.TransactionFields;
 import com.hunk.nobank.contract.TransactionType;
-import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.manager.TransactionDataManager;
 import com.hunk.nobank.model.TransactionReqPackage;
 import com.hunk.test.utils.NetworkHandlerStub;
@@ -19,6 +20,7 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -100,22 +102,8 @@ public class TransactionDataManagerTest {
         realResp.Response = new ArrayList<>();
         realResp.Response.add(transactionFields);
 
-        mNetworkHandlerStub.setNextResponse(realResp);
-
-        transactionDataManager.fetchTransactions(false, new ManagerListener() {
-            @Override
-            public void success(String managerId, String messageId, Object data) {
-                RealResp<List<TransactionFields>> realResp = (RealResp<List<TransactionFields>>) data;
-                Assert.assertEquals(1, realResp.Response.size());
-                Assert.assertEquals("XXX", realResp.Response.get(0).getTitle());
-            }
-
-            @Override
-            public void failed(String managerId, String messageId, Object data) {
-
-            }
-        });
-
+        TransactionReqPackage.cache.setCache(
+                realResp, new TransactionReqPackage(new AccountSummary(), new Date().getTime()));
 
         TransactionFields transactionFields2 = new TransactionFields("XXX2", 1000, TransactionType.DEPOSIT, 1000);
         RealResp<List<TransactionFields>> realResp2 = new RealResp<>();

--- a/NobankCore/noBank/src/test/java/com/hunk/test/nobank/flowTest/ScreenFlowTest.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/nobank/flowTest/ScreenFlowTest.java
@@ -5,9 +5,9 @@ import android.os.Build;
 
 import com.hunk.nobank.BuildConfig;
 import com.hunk.nobank.Core;
-import com.hunk.nobank.manager.flow.ScreenFlow;
-import com.hunk.nobank.manager.flow.ScreenFlowManager;
-import com.hunk.nobank.manager.flow.ScreenNode;
+import com.hunk.nobank.manager.flowBasic.ScreenFlow;
+import com.hunk.nobank.manager.ScreenFlowManager;
+import com.hunk.nobank.manager.flowBasic.ScreenNode;
 import com.hunk.test.utils.TestNoBankApplication;
 
 import org.junit.Test;

--- a/NobankCore/noBank/src/test/java/com/hunk/test/nobank/uiTest/BalanceFragmentTest.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/nobank/uiTest/BalanceFragmentTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
 
 import java.util.ArrayList;
@@ -60,6 +61,8 @@ public class BalanceFragmentTest extends NBAbstractTest {
 
         BalanceFragment balanceFragment = new BalanceFragment();
         SupportFragmentTestUtil.startFragment(balanceFragment);
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Assert.assertNotNull(balanceFragment);
         Assert.assertNotNull(balanceFragment.getView());

--- a/NobankCore/noBank/src/test/java/com/hunk/test/nobank/uiTest/LoginPageActivityTest.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/nobank/uiTest/LoginPageActivityTest.java
@@ -69,7 +69,8 @@ public class LoginPageActivityTest extends NBAbstractTest {
 
         activity.submit();
 
-        // check next started activity
+        // check next started activity. There's two API fetch will run in handler, so call twice.
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         ShadowActivity si = Shadows.shadowOf(activity);

--- a/NobankCore/noBank/src/test/java/com/hunk/test/nobank/uiTest/TransactionListFragmentTest.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/nobank/uiTest/TransactionListFragmentTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
 import org.robolectric.util.ReflectionHelpers;
 
@@ -69,6 +70,8 @@ public class TransactionListFragmentTest extends NBAbstractTest {
 
         Assert.assertNotNull(transactionListFragment);
         Assert.assertNotNull(transactionListFragment.getView());
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         TransactionListAdapter transactionListAdapter = ReflectionHelpers.getField(transactionListFragment, "mTransactionListAdapter");
         Assert.assertEquals("Move to vault", transactionListAdapter.getItem(0).getTransactionFields().getTitle());

--- a/NobankCore/noBank/src/test/java/com/hunk/test/utils/NetworkHandlerStub.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/utils/NetworkHandlerStub.java
@@ -24,6 +24,10 @@ public class NetworkHandlerStub extends NetworkHandler {
     }
 
     @Override
+    protected void setupVolley(Context ctx) {
+    }
+
+    @Override
     public void fireRequest(final ManagerListener listener, final BaseReqPackage req, final String managerId, final String messageId) {
         mHandler.postDelayed(new Runnable() {
             @Override

--- a/NobankCore/noBank/src/test/java/com/hunk/test/utils/NetworkHandlerStub.java
+++ b/NobankCore/noBank/src/test/java/com/hunk/test/utils/NetworkHandlerStub.java
@@ -1,34 +1,47 @@
 package com.hunk.test.utils;
 
 import android.content.Context;
+import android.os.Handler;
+import android.os.Message;
 
 import com.hunk.nobank.contract.RealResp;
 import com.hunk.nobank.extension.network.BaseReqPackage;
+import com.hunk.nobank.extension.network.MyNetworkHandler;
 import com.hunk.nobank.extension.network.NetworkHandler;
-import com.hunk.nobank.manager.ManagerListener;
+import com.hunk.nobank.manager.dataBasic.ManagerListener;
 import com.hunk.nobank.model.Cacheable;
 
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 
 public class NetworkHandlerStub extends NetworkHandler {
+    private final Handler mHandler;
     private Queue<RealResp<?>> prepareList = new ArrayBlockingQueue<>(50);
 
     public NetworkHandlerStub(Context ctx) {
         super(ctx);
+        mHandler = new MyNetworkHandler.MyHandler();
     }
 
     @Override
-    public void fireRequest(ManagerListener listener, BaseReqPackage req, String managerId, String messageId) {
-        RealResp<?> nextRealResp = prepareList.poll();
-        if (isRespSuccessfully(nextRealResp)) {
-            if (req instanceof Cacheable) {
-                ((Cacheable) req).setCache(nextRealResp, req);
+    public void fireRequest(final ManagerListener listener, final BaseReqPackage req, final String managerId, final String messageId) {
+        mHandler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                Message message = Message.obtain();
+                RealResp<?> nextRealResp = prepareList.poll();
+                if (isRespSuccessfully(nextRealResp)) {
+                    if (req instanceof Cacheable) {
+                        ((Cacheable) req).setCache(nextRealResp, req);
+                    }
+                    message.what = 1;
+                } else {
+                    message.what = 0;
+                }
+                message.obj = new MyNetworkHandler.Wrapper(listener, nextRealResp, managerId, messageId);
+                mHandler.sendMessage(message);
             }
-            listener.success(managerId, messageId, nextRealResp);
-        } else {
-            listener.failed(managerId, messageId, nextRealResp);
-        }
+        }, 100);
     }
 
     public void setNextResponse(RealResp<?> realResp) {


### PR DESCRIPTION
If we will fetch something from server, we will use cache pattern to do that, and show Loading dialog whatever there's a cache or not. But this will make loading dialog splash when there has a cache. In this pull request, I changed fetchXXX method(), made it return a Boolean value to tell caller whether there has a cache.